### PR TITLE
Pin actions to their SHAs and drop usage of `tj-actions/changed-files`

### DIFF
--- a/.github/workflows/add-new-subscriber.yaml
+++ b/.github/workflows/add-new-subscriber.yaml
@@ -5,7 +5,7 @@ jobs:
     name: "Validate new subscriber"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
       - name: Checkout Pyodide Main

--- a/.github/workflows/add-new-subscriber.yaml
+++ b/.github/workflows/add-new-subscriber.yaml
@@ -12,9 +12,14 @@ jobs:
         run: git clone https://github.com/pyodide/pyodide.git
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v40
-        with:
-          files: packages/*.json
+        run: |
+          CHANGED_FILES=$(git diff --name-only origin/$GITHUB_BASE_REF...HEAD)
+
+          ALL_CHANGED_FILES=$(echo "$CHANGED_FILES" | grep "^packages/.*\.json$" || echo "")
+
+          echo "all_changed_files<<EOF" >> $GITHUB_OUTPUT
+          echo "$ALL_CHANGED_FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - name: Validate new subscriber files
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do

--- a/.github/workflows/integrate-prs.yaml
+++ b/.github/workflows/integrate-prs.yaml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       include: ${{ steps.generate-matrix.outputs.include }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
       - id: generate-matrix
@@ -37,7 +37,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
       - name: Setup Git
@@ -45,7 +45,7 @@ jobs:
           git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
           git config --global user.email "username@users.noreply.github.com"
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: '3.11'
           cache: 'pip'


### PR DESCRIPTION
Closes #4, and sourced from https://github.com/tj-actions/changed-files/issues/2463#issuecomment-2726354062.